### PR TITLE
Check if responseMessage exists

### DIFF
--- a/src/windowPostMessageProxy.ts
+++ b/src/windowPostMessageProxy.ts
@@ -199,7 +199,9 @@ export class WindowPostMessageProxy {
         if (handler.test(message)) {
           Promise.resolve(handler.handle(message))
             .then(responseMessage => {
-              this.sendResponse(sendingWindow, responseMessage, trackingProperties);
+              if (responseMessage) {
+                this.sendResponse(sendingWindow, responseMessage, trackingProperties);
+              }
             });
 
           return true;


### PR DESCRIPTION
after request is handled successfully, check if responseMessage is not null. If it's not, then send it back, if it's null, don't do anything. 
If we continued sending back undefined responseMessage, then the code later would complain (e.g. defaultAddTrackingProperties would fail)
