### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const message = {
     key: "Value"
 };
 
-windowPostMessageProxy.postMessage(iframe.conentWindow, message);
+windowPostMessageProxy.postMessage(iframe.contentWindow, message);
 ```
 The message is actually modified before it's sent to become:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const message = {
     key: "Value"
 };
 
-windowPostMessageProxy.postMessage(iframe.conentWindow, message)
+windowPostMessageProxy.postMessage(iframe.contentWindow, message)
     .then(response => {
         
     });


### PR DESCRIPTION
Fix typo in README.md file:

iframe.conentWindow -> Should be -> iframe.contentWindow