### PR TITLE
Fixes #14 - Method sendResponse with undefined targetWindow

### DIFF
--- a/src/windowPostMessageProxy.ts
+++ b/src/windowPostMessageProxy.ts
@@ -203,6 +203,10 @@ export class WindowPostMessageProxy {
    * Response messages re-use tracking properties from a previous request message.
    */
   private sendResponse(targetWindow: Window, message: any, trackingProperties: ITrackingProperties): void {
+    if(!targetWindow) {
+      return;
+    }
+    
     this.addTrackingProperties(message, trackingProperties);
 
     if (this.logMessages) {


### PR DESCRIPTION
This checks in the targetWindow is defined before execute this method.